### PR TITLE
fix: WAFHandler returns 'waf-blocked' instead of 'rate-limit' (#7)

### DIFF
--- a/src/engine/handlers/WAFHandler.ts
+++ b/src/engine/handlers/WAFHandler.ts
@@ -22,7 +22,7 @@ export class WAFHandler implements NodeRequestHandler {
     const isBlocked = Math.random() * 100 < data.blockRate;
 
     if (isBlocked) {
-      return { action: 'reject', reason: 'rate-limit' };
+      return { action: 'reject', reason: 'waf-blocked' };
     }
 
     if (outgoingEdges.length === 0) {

--- a/src/engine/handlers/types.ts
+++ b/src/engine/handlers/types.ts
@@ -35,7 +35,7 @@ export interface ForwardTarget {
 export type RequestDecision =
   | { action: 'forward'; targets: ForwardTarget[] }
   | { action: 'respond'; isError: boolean; delay?: number }
-  | { action: 'reject'; reason: 'rate-limit' | 'auth-failure' | 'capacity' }
+  | { action: 'reject'; reason: 'rate-limit' | 'auth-failure' | 'capacity' | 'waf-blocked' }
   | { action: 'queue'; priority?: number }
   | { action: 'cache-miss'; dbTarget: ForwardTarget; cacheNodeId: string }
   | { action: 'notify'; targets: ForwardTarget[] }; // Fire-and-forget: répond immédiatement, notifie les consumers async


### PR DESCRIPTION
WAF rejections were misclassified as rate-limiting events. Added 'waf-blocked' to RejectionReason type and updated WAFHandler to use it.