### PR TITLE
fix: add missing rejection reason types and use semantic reasons per …

### DIFF
--- a/src/engine/SimulationEngine.ts
+++ b/src/engine/SimulationEngine.ts
@@ -936,7 +936,7 @@ export class SimulationEngine {
 
       case 'reject':
         // Record rejection and send error response
-        this.metrics.recordRejection();
+        this.metrics.recordRejection(decision.reason);
         this.pushMetricsUpdate();
         this.callbacks.onNodeStatusChange(sourceNode.id, 'error');
         simulationEvents.emit(createErrorEvent(sourceNode.id, decision.reason || 'rejected', chainId));

--- a/src/engine/handlers/CircuitBreakerHandler.ts
+++ b/src/engine/handlers/CircuitBreakerHandler.ts
@@ -50,14 +50,14 @@ export class CircuitBreakerHandler implements NodeRequestHandler {
         cbState.halfOpenRequests = 0;
         cbState.successCount = 0;
       } else {
-        return { action: 'reject', reason: 'capacity' };
+        return { action: 'reject', reason: 'circuit-open' };
       }
     }
 
     // Half-open: limit concurrent requests
     if (cbState.state === 'half-open') {
       if (cbState.halfOpenRequests >= data.halfOpenMaxRequests) {
-        return { action: 'reject', reason: 'capacity' };
+        return { action: 'reject', reason: 'circuit-open' };
       }
       cbState.halfOpenRequests++;
     }

--- a/src/engine/handlers/FirewallHandler.ts
+++ b/src/engine/handlers/FirewallHandler.ts
@@ -22,12 +22,12 @@ export class FirewallHandler implements NodeRequestHandler {
     if (data.defaultAction === 'deny') {
       // Default deny: only allow if request port is explicitly in allowedPorts
       if (requestPort == null || !data.allowedPorts.includes(requestPort)) {
-        return { action: 'reject', reason: 'blocked' };
+        return { action: 'reject', reason: 'firewall-blocked' };
       }
     } else {
       // Default allow: block only if a port is specified and not in allowedPorts
       if (requestPort != null && data.allowedPorts.length > 0 && !data.allowedPorts.includes(requestPort)) {
-        return { action: 'reject', reason: 'blocked' };
+        return { action: 'reject', reason: 'firewall-blocked' };
       }
     }
 

--- a/src/engine/handlers/MessageQueueHandler.ts
+++ b/src/engine/handlers/MessageQueueHandler.ts
@@ -68,7 +68,7 @@ export class MessageQueueHandler implements NodeRequestHandler {
     // Vérifier la capacité de la file
     if (state.messages.length >= data.configuration.maxQueueSize) {
       state.messagesDeadLettered++;
-      return { action: 'reject', reason: 'capacity' };
+      return { action: 'reject', reason: 'queue-full' };
     }
 
     // Publier le message dans la file

--- a/src/engine/handlers/__tests__/FirewallHandler.test.ts
+++ b/src/engine/handlers/__tests__/FirewallHandler.test.ts
@@ -50,7 +50,7 @@ describe('FirewallHandler', () => {
       const decision = handler.handleRequestArrival(node, createContext(), [createEdge('s-1')], []);
       expect(decision.action).toBe('reject');
       if (decision.action === 'reject') {
-        expect(decision.reason).toBe('blocked');
+        expect(decision.reason).toBe('firewall-blocked');
       }
     });
 
@@ -59,7 +59,7 @@ describe('FirewallHandler', () => {
       const decision = handler.handleRequestArrival(node, createContext(3000), [createEdge('s-1')], []);
       expect(decision.action).toBe('reject');
       if (decision.action === 'reject') {
-        expect(decision.reason).toBe('blocked');
+        expect(decision.reason).toBe('firewall-blocked');
       }
     });
 
@@ -94,7 +94,7 @@ describe('FirewallHandler', () => {
       const decision = handler.handleRequestArrival(node, createContext(3000), [createEdge('s-1')], []);
       expect(decision.action).toBe('reject');
       if (decision.action === 'reject') {
-        expect(decision.reason).toBe('blocked');
+        expect(decision.reason).toBe('firewall-blocked');
       }
     });
 

--- a/src/engine/handlers/types.ts
+++ b/src/engine/handlers/types.ts
@@ -30,12 +30,27 @@ export interface ForwardTarget {
 }
 
 /**
+ * Raisons de rejet possibles par les handlers
+ */
+export type RejectionReason =
+  | 'rate-limit'
+  | 'auth-failure'
+  | 'capacity'
+  | 'waf-blocked'
+  | 'firewall-blocked'
+  | 'timeout'
+  | 'circuit-open'
+  | 'oom-killed'
+  | 'dns-failure'
+  | 'queue-full';
+
+/**
  * Décision retournée par un handler après traitement
  */
 export type RequestDecision =
   | { action: 'forward'; targets: ForwardTarget[] }
   | { action: 'respond'; isError: boolean; delay?: number }
-  | { action: 'reject'; reason: 'rate-limit' | 'auth-failure' | 'capacity' | 'waf-blocked' }
+  | { action: 'reject'; reason: RejectionReason }
   | { action: 'queue'; priority?: number }
   | { action: 'cache-miss'; dbTarget: ForwardTarget; cacheNodeId: string }
   | { action: 'notify'; targets: ForwardTarget[] }; // Fire-and-forget: répond immédiatement, notifie les consumers async

--- a/src/engine/metrics.ts
+++ b/src/engine/metrics.ts
@@ -1,4 +1,5 @@
 import type { SimulationMetrics, ExtendedSimulationMetrics, ResourceSample, ClientGroupMetrics, TimeSeriesSnapshot } from '@/types';
+import type { RejectionReason } from './handlers/types';
 
 /**
  * Collecteur de metriques pour la simulation.
@@ -15,6 +16,7 @@ export class MetricsCollector {
   // Extended metrics for stress testing
   private resourceHistory: ResourceSample[] = [];
   private rejectionCount: number = 0;
+  private rejectionsByReason: Map<RejectionReason, number> = new Map();
   private queueMetrics = {
     totalQueued: 0,
     maxQueueDepth: 0,
@@ -174,6 +176,7 @@ export class MetricsCollector {
     this.latencies = [];
     this.resourceHistory = [];
     this.rejectionCount = 0;
+    this.rejectionsByReason.clear();
     this.queueMetrics = {
       totalQueued: 0,
       maxQueueDepth: 0,
@@ -190,8 +193,11 @@ export class MetricsCollector {
   // Extended Methods for Stress Testing
   // ============================================
 
-  recordRejection(): void {
+  recordRejection(reason?: RejectionReason): void {
     this.rejectionCount++;
+    if (reason) {
+      this.rejectionsByReason.set(reason, (this.rejectionsByReason.get(reason) || 0) + 1);
+    }
   }
 
   recordQueued(queueDepth: number): void {
@@ -284,6 +290,7 @@ export class MetricsCollector {
         this.metrics.requestsSent > 0
           ? (this.rejectionCount / this.metrics.requestsSent) * 100
           : 0,
+      rejectionsByReason: new Map(this.rejectionsByReason),
       resourceHistory: [...this.resourceHistory],
       clientGroupStats: new Map(this.clientGroupStats),
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -469,6 +469,7 @@ export interface ExtendedSimulationMetrics extends SimulationMetrics {
   // Métriques rejets
   requestsRejected: number;
   rejectionRate: number;
+  rejectionsByReason: Map<string, number>;
 
   // Historique ressources
   resourceHistory: ResourceSample[];


### PR DESCRIPTION
…handler (#9)

Extract RejectionReason type with 10 values: rate-limit, auth-failure, capacity, waf-blocked, firewall-blocked, timeout, circuit-open, oom-killed, dns-failure, queue-full. Update handlers to use correct reasons: FirewallHandler→firewall-blocked, CircuitBreakerHandler→circuit-open, MessageQueueHandler→queue-full. Track rejections by reason in MetricsCollector.