### PR TITLE
feat: enrich RequestContext with httpMethod, queryType, contentType, …

### DIFF
--- a/src/engine/SimulationEngine.ts
+++ b/src/engine/SimulationEngine.ts
@@ -109,6 +109,48 @@ interface QueuedRequest {
 }
 
 /**
+ * Derive queryType from httpMethod.
+ * GET → read, POST/PUT/DELETE → write.
+ */
+function deriveQueryType(method?: string): 'read' | 'write' | 'transaction' {
+  if (!method || method === 'GET') return 'read';
+  return 'write';
+}
+
+/**
+ * Infer contentType from request path.
+ * /static/** or known extensions → static, /api/** → dynamic, otherwise user-specific.
+ */
+function inferContentType(path?: string): 'static' | 'dynamic' | 'user-specific' {
+  if (!path) return 'dynamic';
+  if (path.startsWith('/static') || /\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot)$/i.test(path)) return 'static';
+  if (path.startsWith('/api') || path.startsWith('/graphql')) return 'dynamic';
+  return 'user-specific';
+}
+
+/**
+ * Default payload size estimates based on HTTP method.
+ */
+function estimatePayloadSize(method?: string): number {
+  if (!method || method === 'GET' || method === 'DELETE') return 0;
+  return 1024; // 1KB default for POST/PUT
+}
+
+/**
+ * Generate a pseudo-random IP for a virtual client.
+ */
+function generateSourceIP(virtualClientId?: number): string {
+  if (virtualClientId != null) {
+    // Deterministic IP per virtual client
+    const octet3 = Math.floor(virtualClientId / 256) % 256;
+    const octet4 = virtualClientId % 256;
+    return `10.0.${octet3}.${octet4 || 1}`;
+  }
+  // Random IP for http-client nodes
+  return `10.0.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 255) + 1}`;
+}
+
+/**
  * Suivi d'une chaine de requete a travers la topologie.
  * Enregistre le chemin complet (noeuds et aretes traverses) et l'etat cache-aside.
  */
@@ -120,6 +162,12 @@ interface RequestChain {
   virtualClientId?: number;
   startTime: number;
   requestPath?: string;           // Path HTTP de la requête (ex: "/api/orders")
+  // Enriched context (Issue #4)
+  httpMethod?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  queryType?: 'read' | 'write' | 'transaction';
+  contentType?: 'static' | 'dynamic' | 'user-specific';
+  payloadSizeBytes?: number;
+  sourceIP?: string;
   // Cache-aside pattern tracking
   cacheHit?: boolean;             // True si cache hit, false si miss
   cacheNodeId?: string;           // ID du cache pour stockage après DB
@@ -611,6 +659,7 @@ export class SimulationEngine {
     if (!chain) {
       // Get the path from the client node data
       const clientData = client.data as HttpClientNodeData;
+      const method = clientData.method;
       chain = {
         id: chainId,
         originNodeId: client.id,
@@ -618,6 +667,11 @@ export class SimulationEngine {
         edgePath: [],
         startTime: Date.now(),
         requestPath: clientData.path,
+        httpMethod: method,
+        queryType: deriveQueryType(method),
+        contentType: inferContentType(clientData.path),
+        payloadSizeBytes: estimatePayloadSize(method),
+        sourceIP: generateSourceIP(),
       };
       this.activeChains.set(chainId, chain);
     }
@@ -667,6 +721,11 @@ export class SimulationEngine {
       edgePath: chain.edgePath,
       requestPath: chain.requestPath,
       targetPort: (edgeData?.targetPort as number) ?? undefined,
+      httpMethod: chain.httpMethod,
+      queryType: chain.queryType,
+      contentType: chain.contentType,
+      payloadSizeBytes: chain.payloadSizeBytes,
+      sourceIP: chain.sourceIP,
       cacheHit: chain.cacheHit,
       cacheNodeId: chain.cacheNodeId,
       waitingForDb: chain.waitingForDb,
@@ -845,6 +904,11 @@ export class SimulationEngine {
       currentPath: chain.currentPath,
       edgePath: chain.edgePath,
       requestPath: chain.requestPath,
+      httpMethod: chain.httpMethod,
+      queryType: chain.queryType,
+      contentType: chain.contentType,
+      payloadSizeBytes: chain.payloadSizeBytes,
+      sourceIP: chain.sourceIP,
       cacheHit: chain.cacheHit,
       cacheNodeId: chain.cacheNodeId,
       waitingForDb: chain.waitingForDb,
@@ -1093,6 +1157,11 @@ export class SimulationEngine {
       edgePath: chain.edgePath,
       requestPath: chain.requestPath,
       targetPort: (chainEdgeData?.targetPort as number) ?? undefined,
+      httpMethod: chain.httpMethod,
+      queryType: chain.queryType,
+      contentType: chain.contentType,
+      payloadSizeBytes: chain.payloadSizeBytes,
+      sourceIP: chain.sourceIP,
       cacheHit: chain.cacheHit,
       cacheNodeId: chain.cacheNodeId,
       waitingForDb: chain.waitingForDb,
@@ -1291,6 +1360,11 @@ export class SimulationEngine {
             currentPath: chain.currentPath,
             edgePath: chain.edgePath,
             requestPath: chain.requestPath,
+            httpMethod: chain.httpMethod,
+            queryType: chain.queryType,
+            contentType: chain.contentType,
+            payloadSizeBytes: chain.payloadSizeBytes,
+            sourceIP: chain.sourceIP,
           };
           handler.handleResponsePassthrough(currentNode, responseContext, isError);
         }
@@ -1465,6 +1539,11 @@ export class SimulationEngine {
       virtualClientId,
       startTime: Date.now(),
       requestPath: reqType.path,
+      httpMethod: reqType.method,
+      queryType: deriveQueryType(reqType.method),
+      contentType: inferContentType(reqType.path),
+      payloadSizeBytes: estimatePayloadSize(reqType.method),
+      sourceIP: generateSourceIP(virtualClientId),
     };
     this.activeChains.set(chainId, chain);
 

--- a/src/engine/handlers/CDNHandler.ts
+++ b/src/engine/handlers/CDNHandler.ts
@@ -12,14 +12,25 @@ export class CDNHandler implements NodeRequestHandler {
 
   handleRequestArrival(
     node: Node,
-    _context: RequestContext,
+    context: RequestContext,
     outgoingEdges: Edge[],
     _allNodes: Node[]
   ): RequestDecision {
     const data = node.data as CDNNodeData;
 
-    // Simulate cache hit/miss based on ratio
-    const isHit = Math.random() * 100 < data.cacheHitRatio;
+    // Adjust cache hit ratio based on content type
+    let effectiveHitRatio = data.cacheHitRatio;
+    if (context.contentType === 'static') {
+      // Static content has higher cache hit ratio (up to 99%)
+      effectiveHitRatio = Math.min(99, data.cacheHitRatio * 1.3);
+    } else if (context.contentType === 'user-specific') {
+      // User-specific content is rarely cached
+      effectiveHitRatio = data.cacheHitRatio * 0.3;
+    }
+    // 'dynamic' uses the base ratio as-is
+
+    // Simulate cache hit/miss based on adjusted ratio
+    const isHit = Math.random() * 100 < effectiveHitRatio;
 
     if (isHit) {
       return {

--- a/src/engine/handlers/CloudStorageHandler.ts
+++ b/src/engine/handlers/CloudStorageHandler.ts
@@ -9,7 +9,6 @@ export class CloudStorageHandler implements NodeRequestHandler {
 
   getProcessingDelay(node: Node, speed: number): number {
     const data = node.data as CloudStorageNodeData;
-    // Average of read/write latency
     return data.readLatencyMs / speed;
   }
 
@@ -23,11 +22,12 @@ export class CloudStorageHandler implements NodeRequestHandler {
 
   handleRequestArrival(
     node: Node,
-    _context: RequestContext,
+    context: RequestContext,
     outgoingEdges: Edge[],
     _allNodes: Node[]
   ): RequestDecision {
     const data = node.data as CloudStorageNodeData;
+    const method = context.httpMethod || 'GET';
 
     // Rate limiting
     const count = this.requestCounts.get(node.id) || 0;
@@ -41,15 +41,22 @@ export class CloudStorageHandler implements NodeRequestHandler {
       setTimeout(() => this.requestCounts.set(node.id, 0), 1000);
     }
 
+    // Differentiate latency based on HTTP method
+    const delay = (method === 'POST' || method === 'PUT')
+      ? data.writeLatencyMs
+      : method === 'DELETE'
+        ? data.writeLatencyMs * 0.5
+        : data.readLatencyMs;
+
     // Storage is typically a terminal node (no outgoing)
     if (outgoingEdges.length === 0) {
-      return { action: 'respond', isError: false };
+      return { action: 'respond', isError: false, delay };
     }
 
     const edge = outgoingEdges[0];
     return {
       action: 'forward',
-      targets: [{ nodeId: edge.target, edgeId: edge.id }],
+      targets: [{ nodeId: edge.target, edgeId: edge.id, delay }],
     };
   }
 }

--- a/src/engine/handlers/DatabaseHandler.ts
+++ b/src/engine/handlers/DatabaseHandler.ts
@@ -48,8 +48,9 @@ export class DatabaseHandler implements NodeRequestHandler {
     // Générer un ID de requête unique
     const queryId = `${context.chainId}-${this.queryCounter++}`;
 
-    // Exécuter la requête
-    const { accepted } = this.manager.executeQuery(node.id, queryId, 'read');
+    // Exécuter la requête avec le type dérivé du contexte
+    const queryType = context.queryType || 'read';
+    const { accepted } = this.manager.executeQuery(node.id, queryId, queryType);
 
     if (!accepted) {
       return { action: 'reject', reason: 'capacity' };

--- a/src/engine/handlers/FirewallHandler.ts
+++ b/src/engine/handlers/FirewallHandler.ts
@@ -19,6 +19,13 @@ export class FirewallHandler implements NodeRequestHandler {
     const data = node.data as FirewallNodeData;
     const requestPort = context.targetPort;
 
+    // Check IP filtering if blockedIPs is configured
+    if (context.sourceIP && data.blockedIPs.length > 0) {
+      if (data.blockedIPs.includes(context.sourceIP)) {
+        return { action: 'reject', reason: 'firewall-blocked' };
+      }
+    }
+
     if (data.defaultAction === 'deny') {
       // Default deny: only allow if request port is explicitly in allowedPorts
       if (requestPort == null || !data.allowedPorts.includes(requestPort)) {

--- a/src/engine/handlers/types.ts
+++ b/src/engine/handlers/types.ts
@@ -14,6 +14,13 @@ export interface RequestContext {
   requestPath?: string;
   // Port cible sur le nœud courant (provient de l'edge data targetPort)
   targetPort?: number;
+  // Enriched context fields (Issue #4)
+  httpMethod?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  queryType?: 'read' | 'write' | 'transaction';
+  contentType?: 'static' | 'dynamic' | 'user-specific';
+  payloadSizeBytes?: number;
+  sourceIP?: string;
+
   // État spécifique au cache-aside pattern
   cacheHit?: boolean;
   cacheNodeId?: string;


### PR DESCRIPTION
…payloadSize, sourceIP (#4)

Add 5 new fields to RequestContext and populate them from http-client and client-group configs. Update handlers to use enriched context:
- DatabaseHandler: uses queryType for read/write query differentiation
- CDNHandler: adjusts cache hit ratio based on contentType
- CloudStorageHandler: differentiates read/write/delete latency via httpMethod
- FirewallHandler: checks sourceIP against blockedIPs for IP filtering