### PR TITLE
feat: differentiate read/write/transaction operations in DatabaseHand…

### DIFF
--- a/src/components/nodes/DatabaseNode.tsx
+++ b/src/components/nodes/DatabaseNode.tsx
@@ -47,8 +47,11 @@ function DatabaseGauges({ utilization, maxConnections }: { utilization: Database
         <span>conn {activeConnections}/{maxConnections}</span>
         <span>{Math.round(queriesPerSecond)} q/s</span>
       </div>
-      <div className="font-mono text-[9px] text-muted-foreground">
-        latency {avgQueryTime.toFixed(1)}ms
+      <div className="flex items-center justify-between font-mono text-[9px] text-muted-foreground">
+        <span>latency {avgQueryTime.toFixed(1)}ms</span>
+        {utilization.queriesByType && (
+          <span>R:{utilization.queriesByType.read} W:{utilization.queriesByType.write} T:{utilization.queriesByType.transaction}</span>
+        )}
       </div>
     </div>
   );

--- a/src/engine/DatabaseManager.ts
+++ b/src/engine/DatabaseManager.ts
@@ -18,6 +18,7 @@ interface DatabaseState {
   utilization: DatabaseUtilization;
   activeQueries: Map<string, ActiveQuery>;
   queriesLastSecond: number[];
+  queriesByType: { read: number; write: number; transaction: number };
 }
 
 /**
@@ -38,6 +39,7 @@ export class DatabaseManager {
       utilization: this.createInitialUtilization(),
       activeQueries: new Map(),
       queriesLastSecond: [],
+      queriesByType: { read: 0, write: 0, transaction: 0 },
     });
   }
 
@@ -116,6 +118,9 @@ export class DatabaseManager {
       estimatedCompletion: now + degradedLatency,
     });
 
+    // Track query type counts
+    state.queriesByType[queryType]++;
+
     // Record for QPS calculation
     state.queriesLastSecond.push(now);
 
@@ -173,6 +178,7 @@ export class DatabaseManager {
       queriesPerSecond,
       connectionPoolUsage: Math.min(100, connectionPoolUsage),
       avgQueryTime,
+      queriesByType: { ...state.queriesByType },
     };
   }
 
@@ -201,6 +207,7 @@ export class DatabaseManager {
       queriesPerSecond: 0,
       connectionPoolUsage: 0,
       avgQueryTime: 0,
+      queriesByType: { read: 0, write: 0, transaction: 0 },
     };
   }
 

--- a/src/engine/SimulationEngine.ts
+++ b/src/engine/SimulationEngine.ts
@@ -705,12 +705,8 @@ export class SimulationEngine {
       client.id, server.id, clientData.method, clientData.path, chainId
     ));
 
-    // Use handler pattern for consistent behavior
-    let processingDelay = this.getNodeProcessingDelay(server);
-    if (effectiveFault === 'degraded') processingDelay *= 3;
-    const outgoingEdges = this.edges.filter((e) => e.source === server.id);
-
     // Build request context for the handler
+    const outgoingEdges = this.edges.filter((e) => e.source === server.id);
     const edgeData = edge.data as Record<string, unknown> | undefined;
     const context: RequestContext = {
       chainId,
@@ -731,6 +727,10 @@ export class SimulationEngine {
       waitingForDb: chain.waitingForDb,
     };
 
+    // Use handler pattern for consistent behavior
+    let processingDelay = this.getNodeProcessingDelay(server, context);
+    if (effectiveFault === 'degraded') processingDelay *= 3;
+
     // Emit PROCESSING_START event
     simulationEvents.emit(createProcessingStartEvent(server.id, chainId));
 
@@ -738,6 +738,11 @@ export class SimulationEngine {
     const nodeType = server.type ?? 'default';
     const handler = this.handlerRegistry.getHandler(nodeType);
     let decision = handler.handleRequestArrival(server, context, outgoingEdges, this.nodes);
+
+    // Track database query type metrics
+    if (nodeType === 'database') {
+      this.metrics.recordDatabaseQuery(context.queryType || 'read');
+    }
 
     // Chaos: degraded nodes have 50% chance of error
     if (serverFault === 'degraded' && Math.random() < 0.5) {
@@ -759,10 +764,10 @@ export class SimulationEngine {
    * Get processing delay for a node based on its type
    * Delegates to the appropriate handler
    */
-  private getNodeProcessingDelay(node: Node): number {
+  private getNodeProcessingDelay(node: Node, context?: RequestContext): number {
     const nodeType = node.type ?? 'default';
     const handler = this.handlerRegistry.getHandler(nodeType);
-    return handler.getProcessingDelay(node, this.speed);
+    return handler.getProcessingDelay(node, this.speed, context);
   }
 
   /**
@@ -918,6 +923,11 @@ export class SimulationEngine {
     const nodeType = sourceNode.type ?? 'default';
     const handler = this.handlerRegistry.getHandler(nodeType);
     const decision = handler.handleRequestArrival(sourceNode, context, outgoingEdges, this.nodes);
+
+    // Track database query type metrics
+    if (nodeType === 'database') {
+      this.metrics.recordDatabaseQuery(context.queryType || 'read');
+    }
 
     // Execute the decision
     this.executeDecision(decision, sourceNode, chainId, context);
@@ -1138,13 +1148,6 @@ export class SimulationEngine {
       sourceNode.id, targetNode.id, 'GET', chain.requestPath || '/', chainId
     ));
 
-    let processingDelay = this.getNodeProcessingDelay(targetNode);
-
-    // Chaos: degraded nodes (or with degraded parent) have 3x latency and 50% error injection
-    if (effectiveTargetFault === 'degraded') {
-      processingDelay *= 3;
-    }
-
     // Build request context for the handler
     const fullEdge = this.edges.find((e) => e.id === edge.id);
     const chainEdgeData = fullEdge?.data as Record<string, unknown> | undefined;
@@ -1167,6 +1170,13 @@ export class SimulationEngine {
       waitingForDb: chain.waitingForDb,
     };
 
+    let processingDelay = this.getNodeProcessingDelay(targetNode, context);
+
+    // Chaos: degraded nodes (or with degraded parent) have 3x latency and 50% error injection
+    if (effectiveTargetFault === 'degraded') {
+      processingDelay *= 3;
+    }
+
     // Emit PROCESSING_START event
     simulationEvents.emit(createProcessingStartEvent(targetNode.id, chainId));
 
@@ -1179,6 +1189,11 @@ export class SimulationEngine {
     const nodeType = targetNode.type ?? 'default';
     const handler = this.handlerRegistry.getHandler(nodeType);
     let decision = handler.handleRequestArrival(targetNode, context, outgoingEdges, this.nodes);
+
+    // Track database query type metrics
+    if (nodeType === 'database') {
+      this.metrics.recordDatabaseQuery(context.queryType || 'read');
+    }
 
     // Chaos: degraded nodes have 50% chance of error
     if (targetFault === 'degraded' && Math.random() < 0.5) {
@@ -1611,8 +1626,26 @@ export class SimulationEngine {
 
     const serverState = this.serverStates.get(server.id);
 
+    // Build minimal context for processing delay calculation
+    const edgeData = edge.data as Record<string, unknown> | undefined;
+    const context: RequestContext = {
+      chainId,
+      originNodeId: chain?.originNodeId || clientGroup.id,
+      virtualClientId,
+      startTime: chain?.startTime || Date.now(),
+      currentPath: chain?.currentPath || [server.id],
+      edgePath: chain?.edgePath || [edge.id],
+      requestPath: chain?.requestPath,
+      targetPort: (edgeData?.targetPort as number) ?? undefined,
+      httpMethod: chain?.httpMethod,
+      queryType: chain?.queryType,
+      contentType: chain?.contentType,
+      payloadSizeBytes: chain?.payloadSizeBytes,
+      sourceIP: chain?.sourceIP,
+    };
+
     // Calculate processing delay
-    let processingDelay = this.getNodeProcessingDelay(server);
+    let processingDelay = this.getNodeProcessingDelay(server, context);
 
     if (serverState && server.type === 'http-server') {
       const serverData = server.data as HttpServerNodeData;

--- a/src/engine/handlers/DatabaseHandler.ts
+++ b/src/engine/handlers/DatabaseHandler.ts
@@ -17,10 +17,18 @@ export class DatabaseHandler implements NodeRequestHandler {
     this.manager = manager;
   }
 
-  getProcessingDelay(node: Node, speed: number): number {
+  getProcessingDelay(node: Node, speed: number, context?: RequestContext): number {
     const data = node.data as DatabaseNodeData;
-    // Utiliser la latence de lecture par défaut
-    return data.performance.readLatencyMs / speed;
+    const queryType = context?.queryType || 'read';
+    switch (queryType) {
+      case 'write':
+        return data.performance.writeLatencyMs / speed;
+      case 'transaction':
+        return data.performance.transactionLatencyMs / speed;
+      case 'read':
+      default:
+        return data.performance.readLatencyMs / speed;
+    }
   }
 
   initialize(node: Node): void {

--- a/src/engine/handlers/types.ts
+++ b/src/engine/handlers/types.ts
@@ -82,7 +82,7 @@ export interface NodeRequestHandler {
    * @param speed Multiplicateur de vitesse de simulation
    * @returns Délai en millisecondes
    */
-  getProcessingDelay(node: Node, speed: number): number;
+  getProcessingDelay(node: Node, speed: number, context?: RequestContext): number;
 
   /**
    * Gère l'arrivée d'une requête sur un nœud

--- a/src/engine/metrics.ts
+++ b/src/engine/metrics.ts
@@ -31,6 +31,9 @@ export class MetricsCollector {
   // Per-hierarchy metrics tracking (aggregated by parent)
   private perHierarchyMetrics: Map<string, { cpu: number; memory: number; requests: number; errors: number }> = new Map();
 
+  // Database query type counters
+  private databaseQueryCounts = { read: 0, write: 0, transaction: 0 };
+
   // Time-series snapshots
   private timeSeries: TimeSeriesSnapshot[] = [];
 
@@ -186,12 +189,17 @@ export class MetricsCollector {
     this.clientGroupStats.clear();
     this.perServerMetrics.clear();
     this.perHierarchyMetrics.clear();
+    this.databaseQueryCounts = { read: 0, write: 0, transaction: 0 };
     this.timeSeries = [];
   }
 
   // ============================================
   // Extended Methods for Stress Testing
   // ============================================
+
+  recordDatabaseQuery(queryType: 'read' | 'write' | 'transaction'): void {
+    this.databaseQueryCounts[queryType]++;
+  }
 
   recordRejection(reason?: RejectionReason): void {
     this.rejectionCount++;
@@ -293,6 +301,7 @@ export class MetricsCollector {
       rejectionsByReason: new Map(this.rejectionsByReason),
       resourceHistory: [...this.resourceHistory],
       clientGroupStats: new Map(this.clientGroupStats),
+      databaseQueryCounts: { ...this.databaseQueryCounts },
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -476,6 +476,9 @@ export interface ExtendedSimulationMetrics extends SimulationMetrics {
 
   // Stats par groupe de clients
   clientGroupStats: Map<string, ClientGroupMetrics>;
+
+  // Stats par type de requête DB
+  databaseQueryCounts: { read: number; write: number; transaction: number };
 }
 
 /** Snapshot temporel des metriques pour analyse par intervalle de temps. */
@@ -630,6 +633,7 @@ export interface DatabaseUtilization {
   queriesPerSecond: number;
   connectionPoolUsage: number;  // 0-100%
   avgQueryTime: number;
+  queriesByType: { read: number; write: number; transaction: number };
 }
 
 /** Donnees d'un noeud Database avec pool de connexions, performance et capacite. */


### PR DESCRIPTION
…ler (#6)

- Add optional context param to getProcessingDelay interface
- DatabaseHandler returns writeLatencyMs/transactionLatencyMs based on queryType
- SimulationEngine passes RequestContext to getNodeProcessingDelay at all call sites
- Track queriesByType counters in DatabaseManager and MetricsCollector
- Display R/W/T counts in DatabaseNode UI gauges
- Add databaseQueryCounts to ExtendedSimulationMetrics