### PR TITLE
feat: implement ACK, visibility timeout, and retry logic in MessageQu…

### DIFF
--- a/src/engine/SimulationEngine.ts
+++ b/src/engine/SimulationEngine.ts
@@ -1809,12 +1809,14 @@ export class SimulationEngine {
         });
       });
 
-      // Sample Message Queue stats
+      // Sample Message Queue stats (tick visibility timeouts + collect metrics)
       const messageQueueNodes = this.nodes.filter((n) => n.type === 'message-queue');
       messageQueueNodes.forEach((node) => {
+        // Tick: check visibility timeouts, handle retries and DLQ
+        this.messageQueueHandler.tick(node.id);
+
         const stats = this.messageQueueHandler.getStats(node.id);
         if (stats && this.callbacks.onMessageQueueUpdate) {
-          const data = node.data as MessageQueueNodeData;
           const metrics = this.metrics.getMetrics();
           const elapsedSeconds = metrics.startTime ? (Date.now() - metrics.startTime) / 1000 : 1;
           const throughput = elapsedSeconds > 0 ? stats.messagesConsumed / elapsedSeconds : 0;
@@ -1824,8 +1826,10 @@ export class SimulationEngine {
             messagesPublished: stats.messagesPublished,
             messagesConsumed: stats.messagesConsumed,
             messagesDeadLettered: stats.messagesDeadLettered,
-            avgProcessingTime: data.performance.publishLatencyMs + data.performance.consumeLatencyMs,
+            avgProcessingTime: stats.avgProcessingTime,
             throughput,
+            messagesInFlight: stats.messagesInFlight,
+            messagesRetried: stats.messagesRetried,
           };
 
           this.callbacks.onMessageQueueUpdate(node.id, utilization);

--- a/src/engine/handlers/MessageQueueHandler.ts
+++ b/src/engine/handlers/MessageQueueHandler.ts
@@ -3,13 +3,16 @@ import type { NodeRequestHandler, RequestContext, RequestDecision } from './type
 import type { MessageQueueNodeData } from '@/types';
 
 /**
- * Message dans la file
+ * Message dans la file avec support visibility timeout et retry
  */
 interface QueuedMessage {
   id: string;
   chainId: string;
   priority: number;
   enqueuedAt: number;
+  retryCount: number;
+  invisibleUntil: number | null;  // timestamp when message becomes visible again
+  deliveredAt: number | null;     // timestamp of last delivery (for avgProcessingTime)
 }
 
 /**
@@ -20,13 +23,17 @@ interface QueueState {
   config: MessageQueueNodeData;
   messages: QueuedMessage[];
   messagesPublished: number;
-  messagesConsumed: number;
+  messagesConsumed: number;       // Permanently ACKed
   messagesDeadLettered: number;
+  messagesRetried: number;        // Total redeliveries
+  totalProcessingTime: number;    // Sum of ACK processing times (ms)
+  ackedCount: number;             // Count of ACKed messages (for avg calculation)
 }
 
 /**
  * Handler pour les nœuds Message Queue.
  * Gère les modes FIFO, priority, et pubsub.
+ * Implémente le pattern visibility timeout avec ACK, retry et Dead Letter Queue.
  */
 export class MessageQueueHandler implements NodeRequestHandler {
   readonly nodeType = 'message-queue';
@@ -36,7 +43,6 @@ export class MessageQueueHandler implements NodeRequestHandler {
 
   getProcessingDelay(node: Node, speed: number): number {
     const data = node.data as MessageQueueNodeData;
-    // Combinaison du publish et consume latency
     return (data.performance.publishLatencyMs + data.performance.consumeLatencyMs) / speed;
   }
 
@@ -49,6 +55,9 @@ export class MessageQueueHandler implements NodeRequestHandler {
       messagesPublished: 0,
       messagesConsumed: 0,
       messagesDeadLettered: 0,
+      messagesRetried: 0,
+      totalProcessingTime: 0,
+      ackedCount: 0,
     });
   }
 
@@ -65,7 +74,7 @@ export class MessageQueueHandler implements NodeRequestHandler {
     const data = node.data as MessageQueueNodeData;
     const state = this.getOrCreateState(node.id, data);
 
-    // Vérifier la capacité de la file
+    // Vérifier la capacité de la file (only count visible + invisible messages)
     if (state.messages.length >= data.configuration.maxQueueSize) {
       state.messagesDeadLettered++;
       return { action: 'reject', reason: 'queue-full' };
@@ -77,6 +86,9 @@ export class MessageQueueHandler implements NodeRequestHandler {
       chainId: context.chainId,
       priority: data.mode === 'priority' ? Math.floor(Math.random() * 10) : 0,
       enqueuedAt: Date.now(),
+      retryCount: 0,
+      invisibleUntil: null,
+      deliveredAt: null,
     };
 
     state.messages.push(message);
@@ -100,22 +112,22 @@ export class MessageQueueHandler implements NodeRequestHandler {
         delay: data.configuration.deliveryDelayMs,
       }));
 
-      // Consommer le message
+      // Consommer le message (pubsub = immediate delivery, auto-ACK)
       this.consumeMessage(node.id);
 
-      // Notify: répond immédiatement au producteur, notifie les consumers async
       return {
         action: 'notify',
         targets,
       };
     }
 
-    // Mode FIFO ou priority: notifier un seul consumer (round-robin implicite)
-    const edgeIndex = state.messagesConsumed % outgoingEdges.length;
+    // Mode FIFO ou priority: deliver to one consumer (round-robin)
+    const consumedCount = state.messagesConsumed + this.getInFlightCount(state);
+    const edgeIndex = consumedCount % outgoingEdges.length;
     const edge = outgoingEdges[edgeIndex];
 
-    // Consommer le message
-    this.consumeMessage(node.id);
+    // Deliver message: set invisibility instead of removing
+    this.deliverMessage(node.id, data);
 
     return {
       action: 'notify',
@@ -130,7 +142,97 @@ export class MessageQueueHandler implements NodeRequestHandler {
   }
 
   /**
-   * Consomme un message de la file
+   * Delivers a message by making it invisible (not removing it).
+   * In auto ACK mode, the message is consumed immediately.
+   */
+  private deliverMessage(nodeId: string, config: MessageQueueNodeData): QueuedMessage | null {
+    const state = this.queueStates.get(nodeId);
+    if (!state) return null;
+
+    // Find the first visible message
+    const index = state.messages.findIndex((m) => m.invisibleUntil === null);
+    if (index === -1) return null;
+
+    const message = state.messages[index];
+
+    if (config.ackMode === 'auto') {
+      // Auto ACK: remove immediately (backward-compatible behavior)
+      state.messages.splice(index, 1);
+      state.messagesConsumed++;
+      return message;
+    }
+
+    // Manual ACK: set visibility timeout
+    const now = Date.now();
+    message.invisibleUntil = now + config.configuration.visibilityTimeoutMs;
+    message.deliveredAt = now;
+    return message;
+  }
+
+  /**
+   * Acknowledge a message — permanently removes it from the queue.
+   * Called when a consumer successfully processes the message.
+   */
+  acknowledgeMessage(nodeId: string, messageId: string): boolean {
+    const state = this.queueStates.get(nodeId);
+    if (!state) return false;
+
+    const index = state.messages.findIndex((m) => m.id === messageId);
+    if (index === -1) return false;
+
+    const message = state.messages[index];
+
+    // Track processing time
+    if (message.deliveredAt) {
+      state.totalProcessingTime += Date.now() - message.deliveredAt;
+      state.ackedCount++;
+    }
+
+    state.messages.splice(index, 1);
+    state.messagesConsumed++;
+    return true;
+  }
+
+  /**
+   * Tick called periodically (from SimulationEngine resource sampling).
+   * Checks visibility timeouts and handles retry/DLQ routing.
+   */
+  tick(nodeId: string): void {
+    const state = this.queueStates.get(nodeId);
+    if (!state) return;
+
+    const now = Date.now();
+    const config = state.config;
+
+    for (const message of state.messages) {
+      // Skip visible messages (not in-flight)
+      if (message.invisibleUntil === null) continue;
+
+      // Check if visibility timeout has expired
+      if (now < message.invisibleUntil) continue;
+
+      // Timeout expired — message was not ACKed in time
+      message.retryCount++;
+      state.messagesRetried++;
+
+      if (config.retryEnabled && message.retryCount <= config.maxRetries) {
+        // Make message visible again for redelivery
+        message.invisibleUntil = null;
+        message.deliveredAt = null;
+      } else {
+        // Max retries exhausted → Dead Letter Queue
+        state.messagesDeadLettered++;
+        // Remove the message from the queue
+        const index = state.messages.indexOf(message);
+        if (index !== -1) {
+          state.messages.splice(index, 1);
+        }
+      }
+    }
+  }
+
+  /**
+   * Backward-compatible consume for pubsub mode (immediate removal)
    */
   private consumeMessage(nodeId: string): QueuedMessage | null {
     const state = this.queueStates.get(nodeId);
@@ -142,6 +244,13 @@ export class MessageQueueHandler implements NodeRequestHandler {
   }
 
   /**
+   * Count messages currently in-flight (invisible)
+   */
+  private getInFlightCount(state: QueueState): number {
+    return state.messages.filter((m) => m.invisibleUntil !== null).length;
+  }
+
+  /**
    * Récupère les statistiques de la file
    */
   getStats(nodeId: string): {
@@ -149,15 +258,25 @@ export class MessageQueueHandler implements NodeRequestHandler {
     messagesPublished: number;
     messagesConsumed: number;
     messagesDeadLettered: number;
+    messagesInFlight: number;
+    messagesRetried: number;
+    avgProcessingTime: number;
   } | null {
     const state = this.queueStates.get(nodeId);
     if (!state) return null;
 
+    const inFlight = this.getInFlightCount(state);
+
     return {
-      queueDepth: state.messages.length,
+      queueDepth: state.messages.length - inFlight, // visible messages only
       messagesPublished: state.messagesPublished,
       messagesConsumed: state.messagesConsumed,
       messagesDeadLettered: state.messagesDeadLettered,
+      messagesInFlight: inFlight,
+      messagesRetried: state.messagesRetried,
+      avgProcessingTime: state.ackedCount > 0
+        ? state.totalProcessingTime / state.ackedCount
+        : 0,
     };
   }
 
@@ -171,6 +290,9 @@ export class MessageQueueHandler implements NodeRequestHandler {
         messagesPublished: 0,
         messagesConsumed: 0,
         messagesDeadLettered: 0,
+        messagesRetried: 0,
+        totalProcessingTime: 0,
+        ackedCount: 0,
       };
       this.queueStates.set(nodeId, state);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -886,6 +886,7 @@ export interface MessageQueueConfiguration {
   maxQueueSize: number;           // Max messages in queue
   messageRetentionMs: number;     // Message retention time
   deliveryDelayMs: number;        // Delivery delay
+  visibilityTimeoutMs: number;    // Time before unACKed message reappears (ms)
 }
 
 /** Latences et debit de la file de messages en ms. */
@@ -903,6 +904,8 @@ export interface MessageQueueUtilization {
   messagesDeadLettered: number;   // Failed messages
   avgProcessingTime: number;      // Average processing time
   throughput: number;             // Current msgs/sec
+  messagesInFlight: number;       // Messages delivered but not yet ACKed
+  messagesRetried: number;        // Total redeliveries due to visibility timeout
 }
 
 /**
@@ -942,6 +945,7 @@ export const defaultMessageQueueNodeData: MessageQueueNodeData = {
     maxQueueSize: 10000,
     messageRetentionMs: 86400000, // 24h
     deliveryDelayMs: 0,
+    visibilityTimeoutMs: 30000,   // 30s default
   },
   performance: {
     publishLatencyMs: 2,


### PR DESCRIPTION
…eueHandler (#8)

Messages are no longer deleted on consumption — they become invisible for a configurable visibilityTimeoutMs. If not ACKed within the timeout, messages reappear for redelivery up to maxRetries, then route to DLQ. New metrics: messagesInFlight, messagesRetried, avgProcessingTime.