### PR TITLE
feat: persist onboarding tour completion state in localStorage

### DIFF
--- a/src/store/onboarding-store.ts
+++ b/src/store/onboarding-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { TOUR_STEPS } from '@/components/onboarding/steps';
 
 interface OnboardingState {
@@ -13,34 +14,42 @@ interface OnboardingState {
   resetTour: () => void;
 }
 
-export const useOnboardingStore = create<OnboardingState>((set, get) => ({
-  hasCompletedTour: false,
-  currentStepIndex: 0,
-  isActive: false,
-
-  startTour: () => set({ isActive: true, currentStepIndex: 0 }),
-
-  advanceStep: () => {
-    const { currentStepIndex } = get();
-    const nextIndex = currentStepIndex + 1;
-    if (nextIndex >= TOUR_STEPS.length) {
-      get().completeTour();
-    } else {
-      set({ currentStepIndex: nextIndex });
-    }
-  },
-
-  completeTour: () =>
-    set({
-      hasCompletedTour: true,
-      isActive: false,
-      currentStepIndex: 0,
-    }),
-
-  resetTour: () =>
-    set({
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    (set, get) => ({
       hasCompletedTour: false,
-      isActive: true,
       currentStepIndex: 0,
+      isActive: false,
+
+      startTour: () => set({ isActive: true, currentStepIndex: 0 }),
+
+      advanceStep: () => {
+        const { currentStepIndex } = get();
+        const nextIndex = currentStepIndex + 1;
+        if (nextIndex >= TOUR_STEPS.length) {
+          get().completeTour();
+        } else {
+          set({ currentStepIndex: nextIndex });
+        }
+      },
+
+      completeTour: () =>
+        set({
+          hasCompletedTour: true,
+          isActive: false,
+          currentStepIndex: 0,
+        }),
+
+      resetTour: () =>
+        set({
+          hasCompletedTour: false,
+          isActive: true,
+          currentStepIndex: 0,
+        }),
     }),
-}));
+    {
+      name: 'onboarding-storage',
+      partialize: (state) => ({ hasCompletedTour: state.hasCompletedTour }),
+    }
+  )
+);


### PR DESCRIPTION
Prevents the onboarding tour from restarting on every page reload by adding Zustand persist middleware to the onboarding store.