### PR TITLE
feat: onboarding tour pointe sur Analyser après simulation + MetricsP…

### DIFF
--- a/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/components/onboarding/OnboardingOverlay.tsx
@@ -204,6 +204,16 @@ export function OnboardingOverlay() {
       return unsub;
     }
 
+    // Watch simulation store for analysis mode activation
+    if (trigger.type === 'analysis-activated') {
+      const unsub = useSimulationStore.subscribe((state) => {
+        if (state.analysisMode) {
+          advanceOnce();
+        }
+      });
+      return unsub;
+    }
+
     // Watch architecture store for node config change
     if (trigger.type === 'node-config-changed') {
       const unsub = useArchitectureStore.subscribe((state) => {
@@ -227,8 +237,6 @@ export function OnboardingOverlay() {
     // Last step → complete tour
     if (currentStepIndex === TOUR_STEPS.length - 1) {
       completeTour();
-      // Close the report drawer after tour completion
-      useSimulationStore.getState().setShowReport(false);
       return;
     }
 
@@ -244,7 +252,8 @@ export function OnboardingOverlay() {
   // we need to allow pointer events on the spotlight hole
   const needsTargetClick =
     currentStep.trigger.type === 'mode-changed' ||
-    currentStep.trigger.type === 'simulation-state-changed';
+    currentStep.trigger.type === 'simulation-state-changed' ||
+    currentStep.trigger.type === 'analysis-activated';
 
   return (
     <>

--- a/src/components/onboarding/steps.ts
+++ b/src/components/onboarding/steps.ts
@@ -8,7 +8,8 @@ export type TourTrigger =
   | { type: 'mode-changed'; targetMode: AppMode }
   | { type: 'simulation-state-changed'; targetState: 'running' | 'idle' | 'paused' }
   | { type: 'node-selected'; nodeType: string }
-  | { type: 'node-config-changed'; nodeType: string; field: string; value: string };
+  | { type: 'node-config-changed'; nodeType: string; field: string; value: string }
+  | { type: 'analysis-activated' };
 
 export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
 
@@ -189,14 +190,6 @@ export const TOUR_STEPS: TourStepConfig[] = [
     trigger: { type: 'simulation-state-changed', targetState: 'paused' },
   },
   {
-    id: 'analyze-button',
-    titleKey: 'onboarding.analyzeButton.title',
-    descriptionKey: 'onboarding.analyzeButton.description',
-    targetSelector: '[data-tour="analyze-button"]',
-    tooltipPosition: 'top',
-    trigger: { type: 'click-next' },
-  },
-  {
     id: 'metrics-tab',
     titleKey: 'onboarding.metricsTab.title',
     descriptionKey: 'onboarding.metricsTab.description',
@@ -239,11 +232,12 @@ export const TOUR_STEPS: TourStepConfig[] = [
     trigger: { type: 'simulation-state-changed', targetState: 'idle' },
   },
   {
-    id: 'view-report',
-    titleKey: 'onboarding.viewReport.title',
-    descriptionKey: 'onboarding.viewReport.description',
-    targetSelector: '[data-tour="report-drawer"]',
-    tooltipPosition: 'bottom',
-    trigger: { type: 'click-next' },
+    id: 'analyze-button',
+    titleKey: 'onboarding.analyzeButton.title',
+    descriptionKey: 'onboarding.analyzeButton.description',
+    targetSelector: '[data-tour="analyze-button"]',
+    tooltipPosition: 'top',
+    trigger: { type: 'analysis-activated' },
+    allowInteraction: true,
   },
 ];

--- a/src/components/simulation/MetricsPanel.tsx
+++ b/src/components/simulation/MetricsPanel.tsx
@@ -483,13 +483,6 @@ export function MetricsPanel() {
   const validationResult = useAppStore((s) => s.validationResult);
   const { events } = useSimulationEvents();
 
-  // Auto-expand when simulation starts
-  useEffect(() => {
-    if (state === 'running') {
-      setIsExpanded(true);
-    }
-  }, [state]);
-
   // Auto-expand and switch to validation tab when validation has errors
   useEffect(() => {
     if (validationResult && validationResult.issues.length > 0) {


### PR DESCRIPTION
…anel fermé au démarrage

- Déplace l'étape analyze-button en fin de tour (après stop-simulation)
- Ajoute le trigger analysis-activated pour détecter le clic sur Analyser
- Supprime l'auto-expand du MetricsPanel au démarrage de la simulation
- Remplace l'ancienne étape view-report par analyze-button interactif