### PR TITLE
feat: add provider presets and capacity limits for Gateway and Load B…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "zustand": "^5.0.9"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2013,6 +2014,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8820,6 +8837,53 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:video": "playwright test tests/e2e/full-walkthrough.spec.ts"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -43,6 +45,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -11,6 +11,9 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { SimulationErrorBoundary } from '@/components/SimulationErrorBoundary';
 import { useSimulationStore } from '@/store/simulation-store';
 import { useProjectStore } from '@/store/project-store';
+import { useArchitectureStore } from '@/store/architecture-store';
+import { useAppStore } from '@/store/app-store';
+import { useOnboardingStore } from '@/store/onboarding-store';
 
 export default function SimulatorPage() {
   const analysisMode = useSimulationStore((s) => s.analysisMode);
@@ -19,6 +22,17 @@ export default function SimulatorPage() {
   useEffect(() => {
     initialize();
   }, [initialize]);
+
+  // Expose stores on window for Playwright e2e tests (dev only)
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      const w = window as Record<string, unknown>;
+      w.__archStore = useArchitectureStore;
+      w.__appStore = useAppStore;
+      w.__simStore = useSimulationStore;
+      w.__onboardingStore = useOnboardingStore;
+    }
+  }, []);
 
   return (
     <div className="h-screen w-screen flex flex-col overflow-hidden">

--- a/src/components/layout/PropertiesPanel.tsx
+++ b/src/components/layout/PropertiesPanel.tsx
@@ -27,6 +27,14 @@ import type { HttpServerNodeData, HttpClientNodeData, ProcessingComplexity, Clie
 import { complexityMultipliers } from '@/types';
 import type { ConnectionProtocol, ComponentType } from '@/types';
 import { validateConnection } from '@/lib/connection-validator';
+import {
+  type LoadBalancerProvider,
+  type ApiGatewayProvider,
+  loadBalancerProviderPresets,
+  apiGatewayProviderPresets,
+  getAvailableLBProviders,
+  getAvailableGWProviders,
+} from '@/data/provider-presets';
 import { useTranslation } from '@/i18n';
 import type { GraphNode } from '@/types/graph';
 
@@ -475,6 +483,7 @@ export function PropertiesPanel() {
             <LoadBalancerConfig
               data={selectedNode.data as LoadBalancerNodeData}
               onUpdate={updateNodeData}
+              hasParent={!!selectedNode.parentId}
             />
           )}
 
@@ -491,6 +500,7 @@ export function PropertiesPanel() {
             <ApiGatewayConfig
               data={selectedNode.data as ApiGatewayNodeData}
               onUpdate={updateNodeData}
+              hasParent={!!selectedNode.parentId}
               availableServices={nodes
                 .filter((n): n is typeof n & { data: HttpServerNodeData } =>
                   n.type === 'http-server' &&
@@ -2243,20 +2253,28 @@ function CacheConfig({ data, onUpdate }: CacheConfigProps) {
 interface LoadBalancerConfigProps {
   data: LoadBalancerNodeData;
   onUpdate: (updates: Partial<LoadBalancerNodeData>) => void;
+  hasParent: boolean;
 }
 
-function LoadBalancerConfig({ data, onUpdate }: LoadBalancerConfigProps) {
+function LoadBalancerConfig({ data, onUpdate, hasParent }: LoadBalancerConfigProps) {
   const config = {
     ...defaultLoadBalancerNodeData,
     ...data,
     healthCheck: { ...defaultLoadBalancerNodeData.healthCheck, ...data.healthCheck },
   };
 
+  const currentProvider = (config.provider || 'generic') as LoadBalancerProvider;
+  const availableProviders = getAvailableLBProviders(hasParent);
+  const currentPreset = loadBalancerProviderPresets[currentProvider] || loadBalancerProviderPresets.generic;
+
   // Local state for sliders
   const [healthCheckInterval, setHealthCheckInterval] = useState(config.healthCheck.intervalMs);
   const [healthCheckTimeout, setHealthCheckTimeout] = useState(config.healthCheck.timeoutMs);
   const [unhealthyThreshold, setUnhealthyThreshold] = useState(config.healthCheck.unhealthyThreshold);
   const [sessionTTL, setSessionTTL] = useState(config.sessionTTLSeconds);
+  const [maxConnections, setMaxConnections] = useState(config.maxConnections);
+  const [maxRPS, setMaxRPS] = useState(config.maxRPS);
+  const [baseLatency, setBaseLatency] = useState(config.baseLatencyMs);
 
   // Sync local state when data changes
   useEffect(() => {
@@ -2264,6 +2282,9 @@ function LoadBalancerConfig({ data, onUpdate }: LoadBalancerConfigProps) {
     setHealthCheckTimeout(config.healthCheck.timeoutMs);
     setUnhealthyThreshold(config.healthCheck.unhealthyThreshold);
     setSessionTTL(config.sessionTTLSeconds);
+    setMaxConnections(config.maxConnections);
+    setMaxRPS(config.maxRPS);
+    setBaseLatency(config.baseLatencyMs);
   }, [data]);
 
   const updateHealthCheck = (updates: Partial<LoadBalancerNodeData['healthCheck']>) => {
@@ -2272,8 +2293,118 @@ function LoadBalancerConfig({ data, onUpdate }: LoadBalancerConfigProps) {
     });
   };
 
+  const handleProviderChange = (provider: LoadBalancerProvider) => {
+    const preset = loadBalancerProviderPresets[provider];
+    // Appliquer les presets du provider
+    const updates: Partial<LoadBalancerNodeData> = {
+      provider,
+      maxConnections: preset.maxConnections,
+      maxRPS: preset.maxRPS,
+      baseLatencyMs: preset.baseLatencyMs,
+      label: preset.label === 'Générique' ? config.label : preset.label,
+    };
+    // Vérifier si l'algorithme actuel est supporté par le provider
+    if (!preset.algorithms.includes(config.algorithm)) {
+      updates.algorithm = preset.algorithms[0];
+    }
+    // Sticky sessions
+    if (!preset.supportsStickySession && config.stickySessions) {
+      updates.stickySessions = false;
+    }
+    onUpdate(updates);
+  };
+
   return (
     <>
+      {/* Provider */}
+      <div className="space-y-3">
+        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+          Provider
+        </span>
+        <Separator />
+        <Select
+          value={currentProvider}
+          onValueChange={(value) => handleProviderChange(value as LoadBalancerProvider)}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {availableProviders.map((provider) => {
+              const preset = loadBalancerProviderPresets[provider];
+              return (
+                <SelectItem key={provider} value={provider}>
+                  {preset.label} ({preset.hostingType === 'self-hosted' ? 'Self-hosted' : preset.hostingType === 'managed' ? 'Managed' : 'Libre'})
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          {currentPreset.description}
+        </p>
+        {currentPreset.hostingType !== 'configurable' && (
+          <Badge variant="outline" className="text-xs">
+            {currentPreset.layer} · {currentPreset.hostingType}
+          </Badge>
+        )}
+      </div>
+
+      {/* Capacity */}
+      <div className="space-y-3">
+        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+          Capacité
+        </span>
+        <Separator />
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <label>Max connexions</label>
+              <span className="text-muted-foreground">{maxConnections.toLocaleString()}</span>
+            </div>
+            <Slider
+              value={[maxConnections]}
+              onValueChange={([value]) => setMaxConnections(value)}
+              onValueCommit={([value]) => onUpdate({ maxConnections: value })}
+              min={100}
+              max={1000000}
+              step={100}
+              disabled={currentProvider !== 'generic'}
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <label>Max RPS</label>
+              <span className="text-muted-foreground">{maxRPS.toLocaleString()}</span>
+            </div>
+            <Slider
+              value={[maxRPS]}
+              onValueChange={([value]) => setMaxRPS(value)}
+              onValueCommit={([value]) => onUpdate({ maxRPS: value })}
+              min={50}
+              max={100000}
+              step={50}
+              disabled={currentProvider !== 'generic'}
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <label>Latence de base</label>
+              <span className="text-muted-foreground">{baseLatency}ms</span>
+            </div>
+            <Slider
+              value={[baseLatency]}
+              onValueChange={([value]) => setBaseLatency(value)}
+              onValueCommit={([value]) => onUpdate({ baseLatencyMs: value })}
+              min={0}
+              max={50}
+              step={1}
+              disabled={currentProvider !== 'generic'}
+            />
+          </div>
+        </div>
+      </div>
+
       {/* Algorithm */}
       <div className="space-y-3">
         <span className="text-xs text-muted-foreground uppercase tracking-wide">
@@ -2288,10 +2419,18 @@ function LoadBalancerConfig({ data, onUpdate }: LoadBalancerConfigProps) {
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="round-robin">Round Robin</SelectItem>
-            <SelectItem value="least-connections">Least Connections</SelectItem>
-            <SelectItem value="ip-hash">IP Hash</SelectItem>
-            <SelectItem value="weighted">Weighted</SelectItem>
+            {currentPreset.algorithms.includes('round-robin') && (
+              <SelectItem value="round-robin">Round Robin</SelectItem>
+            )}
+            {currentPreset.algorithms.includes('least-connections') && (
+              <SelectItem value="least-connections">Least Connections</SelectItem>
+            )}
+            {currentPreset.algorithms.includes('ip-hash') && (
+              <SelectItem value="ip-hash">IP Hash</SelectItem>
+            )}
+            {currentPreset.algorithms.includes('weighted') && (
+              <SelectItem value="weighted">Weighted</SelectItem>
+            )}
           </SelectContent>
         </Select>
         <p className="text-xs text-muted-foreground">
@@ -2371,42 +2510,44 @@ function LoadBalancerConfig({ data, onUpdate }: LoadBalancerConfigProps) {
       </div>
 
       {/* Sticky Sessions */}
-      <div className="space-y-3">
-        <span className="text-xs text-muted-foreground uppercase tracking-wide">
-          Sessions persistantes
-        </span>
-        <Separator />
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <Label htmlFor="sticky-sessions">Activer</Label>
-            <Switch
-              id="sticky-sessions"
-              checked={config.stickySessions}
-              onCheckedChange={(checked) => onUpdate({ stickySessions: checked })}
-            />
-          </div>
-
-          {config.stickySessions && (
-            <div className="space-y-2">
-              <div className="flex justify-between text-sm">
-                <label>Durée de session</label>
-                <span className="text-muted-foreground">{sessionTTL}s</span>
-              </div>
-              <Slider
-                value={[sessionTTL]}
-                onValueChange={([value]) => setSessionTTL(value)}
-                onValueCommit={([value]) => onUpdate({ sessionTTLSeconds: value })}
-                min={60}
-                max={86400}
-                step={60}
+      {currentPreset.supportsStickySession && (
+        <div className="space-y-3">
+          <span className="text-xs text-muted-foreground uppercase tracking-wide">
+            Sessions persistantes
+          </span>
+          <Separator />
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="sticky-sessions">Activer</Label>
+              <Switch
+                id="sticky-sessions"
+                checked={config.stickySessions}
+                onCheckedChange={(checked) => onUpdate({ stickySessions: checked })}
               />
-              <p className="text-xs text-muted-foreground">
-                Les requêtes d'un même client sont routées vers le même serveur
-              </p>
             </div>
-          )}
+
+            {config.stickySessions && (
+              <div className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <label>Durée de session</label>
+                  <span className="text-muted-foreground">{sessionTTL}s</span>
+                </div>
+                <Slider
+                  value={[sessionTTL]}
+                  onValueChange={([value]) => setSessionTTL(value)}
+                  onValueCommit={([value]) => onUpdate({ sessionTTLSeconds: value })}
+                  min={60}
+                  max={86400}
+                  step={60}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Les requêtes d'un même client sont routées vers le même serveur
+                </p>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 }
@@ -2736,10 +2877,11 @@ interface AvailableService {
 interface ApiGatewayConfigProps {
   data: ApiGatewayNodeData;
   onUpdate: (updates: Partial<ApiGatewayNodeData>) => void;
+  hasParent: boolean;
   availableServices: AvailableService[];
 }
 
-function ApiGatewayConfig({ data, onUpdate, availableServices }: ApiGatewayConfigProps) {
+function ApiGatewayConfig({ data, onUpdate, hasParent, availableServices }: ApiGatewayConfigProps) {
   const config = {
     ...defaultApiGatewayNodeData,
     ...data,
@@ -2748,6 +2890,10 @@ function ApiGatewayConfig({ data, onUpdate, availableServices }: ApiGatewayConfi
     routeRules: data.routeRules || [],
   };
 
+  const currentProvider = (config.provider || 'generic') as ApiGatewayProvider;
+  const availableProviders = getAvailableGWProviders(hasParent);
+  const currentPreset = apiGatewayProviderPresets[currentProvider] || apiGatewayProviderPresets.generic;
+
   // Local state for sliders
   const [authFailureRate, setAuthFailureRate] = useState(config.authFailureRate);
   const [requestsPerSecond, setRequestsPerSecond] = useState(config.rateLimiting.requestsPerSecond);
@@ -2755,6 +2901,8 @@ function ApiGatewayConfig({ data, onUpdate, availableServices }: ApiGatewayConfi
   const [timeout, setTimeout] = useState(config.routing.timeout);
   const [baseLatency, setBaseLatency] = useState(config.baseLatencyMs);
   const [errorRate, setErrorRate] = useState(config.errorRate);
+  const [maxConnections, setMaxConnections] = useState(config.maxConnections);
+  const [maxRPS, setMaxRPS] = useState(config.maxRPS);
 
   // Sync local state when data changes
   useEffect(() => {
@@ -2764,7 +2912,25 @@ function ApiGatewayConfig({ data, onUpdate, availableServices }: ApiGatewayConfi
     setTimeout(config.routing.timeout);
     setBaseLatency(config.baseLatencyMs);
     setErrorRate(config.errorRate);
+    setMaxConnections(config.maxConnections);
+    setMaxRPS(config.maxRPS);
   }, [data]);
+
+  const handleProviderChange = (provider: ApiGatewayProvider) => {
+    const preset = apiGatewayProviderPresets[provider];
+    const updates: Partial<ApiGatewayNodeData> = {
+      provider,
+      maxConnections: preset.maxConnections,
+      maxRPS: preset.maxRPS,
+      baseLatencyMs: preset.baseLatencyMs,
+      label: preset.label === 'Générique' ? config.label : preset.label,
+    };
+    // Vérifier si le type d'auth actuel est supporté
+    if (!preset.supportedAuthTypes.includes(config.authType)) {
+      updates.authType = preset.supportedAuthTypes[0];
+    }
+    onUpdate(updates);
+  };
 
   const updateRateLimiting = (updates: Partial<ApiGatewayNodeData['rateLimiting']>) => {
     onUpdate({
@@ -2804,6 +2970,80 @@ function ApiGatewayConfig({ data, onUpdate, availableServices }: ApiGatewayConfi
 
   return (
     <>
+      {/* Provider */}
+      <div className="space-y-3">
+        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+          Provider
+        </span>
+        <Separator />
+        <Select
+          value={currentProvider}
+          onValueChange={(value) => handleProviderChange(value as ApiGatewayProvider)}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {availableProviders.map((provider) => {
+              const preset = apiGatewayProviderPresets[provider];
+              return (
+                <SelectItem key={provider} value={provider}>
+                  {preset.label} ({preset.hostingType === 'self-hosted' ? 'Self-hosted' : preset.hostingType === 'managed' ? 'Managed' : 'Libre'})
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          {currentPreset.description}
+        </p>
+        {currentPreset.hostingType !== 'configurable' && (
+          <Badge variant="outline" className="text-xs">
+            {currentPreset.hostingType}
+          </Badge>
+        )}
+      </div>
+
+      {/* Capacity */}
+      <div className="space-y-3">
+        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+          Capacité
+        </span>
+        <Separator />
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <label>Max connexions</label>
+              <span className="text-muted-foreground">{maxConnections.toLocaleString()}</span>
+            </div>
+            <Slider
+              value={[maxConnections]}
+              onValueChange={([value]) => setMaxConnections(value)}
+              onValueCommit={([value]) => onUpdate({ maxConnections: value })}
+              min={100}
+              max={100000}
+              step={100}
+              disabled={currentProvider !== 'generic'}
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <label>Max RPS</label>
+              <span className="text-muted-foreground">{maxRPS.toLocaleString()}</span>
+            </div>
+            <Slider
+              value={[maxRPS]}
+              onValueChange={([value]) => setMaxRPS(value)}
+              onValueCommit={([value]) => onUpdate({ maxRPS: value })}
+              min={50}
+              max={50000}
+              step={50}
+              disabled={currentProvider !== 'generic'}
+            />
+          </div>
+        </div>
+      </div>
+
       {/* Authentication */}
       <div className="space-y-3">
         <span className="text-xs text-muted-foreground uppercase tracking-wide">
@@ -2821,10 +3061,18 @@ function ApiGatewayConfig({ data, onUpdate, availableServices }: ApiGatewayConfi
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="none">Aucune</SelectItem>
-                <SelectItem value="api-key">Clé API</SelectItem>
-                <SelectItem value="jwt">JWT</SelectItem>
-                <SelectItem value="oauth2">OAuth2</SelectItem>
+                {currentPreset.supportedAuthTypes.includes('none') && (
+                  <SelectItem value="none">Aucune</SelectItem>
+                )}
+                {currentPreset.supportedAuthTypes.includes('api-key') && (
+                  <SelectItem value="api-key">Clé API</SelectItem>
+                )}
+                {currentPreset.supportedAuthTypes.includes('jwt') && (
+                  <SelectItem value="jwt">JWT</SelectItem>
+                )}
+                {currentPreset.supportedAuthTypes.includes('oauth2') && (
+                  <SelectItem value="oauth2">OAuth2</SelectItem>
+                )}
               </SelectContent>
             </Select>
           </div>

--- a/src/data/provider-presets.ts
+++ b/src/data/provider-presets.ts
@@ -1,0 +1,249 @@
+import type { LoadBalancerAlgorithm, ApiGatewayAuthType } from '@/types';
+
+// ============================================
+// Provider Types
+// ============================================
+
+export type LoadBalancerProvider =
+  | 'generic'
+  | 'nginx'
+  | 'haproxy'
+  | 'aws-alb'
+  | 'aws-nlb'
+  | 'traefik'
+  | 'envoy';
+
+export type ApiGatewayProvider =
+  | 'generic'
+  | 'kong'
+  | 'aws-api-gateway'
+  | 'nginx-plus'
+  | 'azure-apim'
+  | 'traefik';
+
+export type ProviderHostingType = 'self-hosted' | 'managed' | 'configurable';
+
+// ============================================
+// Load Balancer Provider Presets
+// ============================================
+
+export interface LoadBalancerProviderPreset {
+  label: string;
+  hostingType: ProviderHostingType;
+  layer: 'L4' | 'L7' | 'L4/L7';
+  maxConnections: number;
+  maxRPS: number;
+  baseLatencyMs: number;
+  algorithms: LoadBalancerAlgorithm[];
+  supportsStickySession: boolean;
+  description: string;
+}
+
+export const loadBalancerProviderPresets: Record<LoadBalancerProvider, LoadBalancerProviderPreset> = {
+  generic: {
+    label: 'Générique',
+    hostingType: 'configurable',
+    layer: 'L7',
+    maxConnections: 10000,
+    maxRPS: 5000,
+    baseLatencyMs: 5,
+    algorithms: ['round-robin', 'least-connections', 'ip-hash', 'weighted'],
+    supportsStickySession: true,
+    description: 'Configuration libre, tous algorithmes disponibles',
+  },
+  nginx: {
+    label: 'NGINX',
+    hostingType: 'self-hosted',
+    layer: 'L7',
+    maxConnections: 10000,
+    maxRPS: 5000,
+    baseLatencyMs: 3,
+    algorithms: ['round-robin', 'least-connections', 'ip-hash', 'weighted'],
+    supportsStickySession: true,
+    description: 'Reverse proxy haute performance, nécessite un host-server',
+  },
+  haproxy: {
+    label: 'HAProxy',
+    hostingType: 'self-hosted',
+    layer: 'L4/L7',
+    maxConnections: 50000,
+    maxRPS: 20000,
+    baseLatencyMs: 1,
+    algorithms: ['round-robin', 'least-connections', 'ip-hash', 'weighted'],
+    supportsStickySession: true,
+    description: 'Load balancer très haute performance L4/L7, nécessite un host-server',
+  },
+  'aws-alb': {
+    label: 'AWS ALB',
+    hostingType: 'managed',
+    layer: 'L7',
+    maxConnections: 100000,
+    maxRPS: 25000,
+    baseLatencyMs: 5,
+    algorithms: ['round-robin', 'least-connections'],
+    supportsStickySession: true,
+    description: 'Application Load Balancer AWS, auto-scaling, standalone uniquement',
+  },
+  'aws-nlb': {
+    label: 'AWS NLB',
+    hostingType: 'managed',
+    layer: 'L4',
+    maxConnections: 1000000,
+    maxRPS: 100000,
+    baseLatencyMs: 1,
+    algorithms: ['round-robin', 'ip-hash'],
+    supportsStickySession: false,
+    description: 'Network Load Balancer AWS, ultra-haute performance L4, standalone uniquement',
+  },
+  traefik: {
+    label: 'Traefik',
+    hostingType: 'self-hosted',
+    layer: 'L7',
+    maxConnections: 10000,
+    maxRPS: 3000,
+    baseLatencyMs: 5,
+    algorithms: ['round-robin', 'weighted'],
+    supportsStickySession: true,
+    description: 'Reverse proxy cloud-native, nécessite un host-server',
+  },
+  envoy: {
+    label: 'Envoy',
+    hostingType: 'self-hosted',
+    layer: 'L7',
+    maxConnections: 20000,
+    maxRPS: 10000,
+    baseLatencyMs: 2,
+    algorithms: ['round-robin', 'least-connections', 'ip-hash', 'weighted'],
+    supportsStickySession: true,
+    description: 'Service mesh proxy, nécessite un host-server',
+  },
+};
+
+// ============================================
+// API Gateway Provider Presets
+// ============================================
+
+export interface ApiGatewayProviderPreset {
+  label: string;
+  hostingType: ProviderHostingType;
+  maxConnections: number;
+  maxRPS: number;
+  baseLatencyMs: number;
+  supportedAuthTypes: ApiGatewayAuthType[];
+  supportsPerRouteRateLimit: boolean;
+  description: string;
+}
+
+export const apiGatewayProviderPresets: Record<ApiGatewayProvider, ApiGatewayProviderPreset> = {
+  generic: {
+    label: 'Générique',
+    hostingType: 'configurable',
+    maxConnections: 10000,
+    maxRPS: 5000,
+    baseLatencyMs: 5,
+    supportedAuthTypes: ['none', 'api-key', 'jwt', 'oauth2'],
+    supportsPerRouteRateLimit: false,
+    description: 'Configuration libre, tous types d\'auth disponibles',
+  },
+  kong: {
+    label: 'Kong',
+    hostingType: 'self-hosted',
+    maxConnections: 10000,
+    maxRPS: 5000,
+    baseLatencyMs: 4,
+    supportedAuthTypes: ['none', 'api-key', 'jwt', 'oauth2'],
+    supportsPerRouteRateLimit: true,
+    description: 'API Gateway extensible par plugins, nécessite un host-server',
+  },
+  'aws-api-gateway': {
+    label: 'AWS API Gateway',
+    hostingType: 'managed',
+    maxConnections: 50000,
+    maxRPS: 10000,
+    baseLatencyMs: 10,
+    supportedAuthTypes: ['none', 'api-key', 'jwt', 'oauth2'],
+    supportsPerRouteRateLimit: true,
+    description: 'API Gateway managé AWS avec throttling intégré, standalone uniquement',
+  },
+  'nginx-plus': {
+    label: 'NGINX Plus',
+    hostingType: 'self-hosted',
+    maxConnections: 10000,
+    maxRPS: 5000,
+    baseLatencyMs: 3,
+    supportedAuthTypes: ['none', 'api-key', 'jwt'],
+    supportsPerRouteRateLimit: false,
+    description: 'API Gateway basé sur NGINX, nécessite un host-server',
+  },
+  'azure-apim': {
+    label: 'Azure APIM',
+    hostingType: 'managed',
+    maxConnections: 25000,
+    maxRPS: 5000,
+    baseLatencyMs: 8,
+    supportedAuthTypes: ['none', 'api-key', 'jwt', 'oauth2'],
+    supportsPerRouteRateLimit: true,
+    description: 'API Management Azure, standalone uniquement',
+  },
+  traefik: {
+    label: 'Traefik',
+    hostingType: 'self-hosted',
+    maxConnections: 5000,
+    maxRPS: 2000,
+    baseLatencyMs: 5,
+    supportedAuthTypes: ['none', 'jwt'],
+    supportsPerRouteRateLimit: false,
+    description: 'Reverse proxy cloud-native avec gateway, nécessite un host-server',
+  },
+};
+
+// ============================================
+// Validation Helpers
+// ============================================
+
+/**
+ * Vérifie si un provider de Load Balancer est compatible avec le placement actuel.
+ * - Self-hosted : doit avoir un parentId (être dans un host-server ou container)
+ * - Managed : ne doit PAS avoir de parentId
+ * - Configurable : pas de restriction
+ */
+export function isLBProviderCompatibleWithPlacement(
+  provider: LoadBalancerProvider,
+  hasParent: boolean
+): boolean {
+  const preset = loadBalancerProviderPresets[provider];
+  if (preset.hostingType === 'self-hosted' && !hasParent) return false;
+  if (preset.hostingType === 'managed' && hasParent) return false;
+  return true;
+}
+
+/**
+ * Vérifie si un provider d'API Gateway est compatible avec le placement actuel.
+ */
+export function isGWProviderCompatibleWithPlacement(
+  provider: ApiGatewayProvider,
+  hasParent: boolean
+): boolean {
+  const preset = apiGatewayProviderPresets[provider];
+  if (preset.hostingType === 'self-hosted' && !hasParent) return false;
+  if (preset.hostingType === 'managed' && hasParent) return false;
+  return true;
+}
+
+/**
+ * Retourne les providers de LB disponibles selon le contexte de placement.
+ */
+export function getAvailableLBProviders(hasParent: boolean): LoadBalancerProvider[] {
+  return (Object.keys(loadBalancerProviderPresets) as LoadBalancerProvider[]).filter(
+    (provider) => isLBProviderCompatibleWithPlacement(provider, hasParent)
+  );
+}
+
+/**
+ * Retourne les providers de Gateway disponibles selon le contexte de placement.
+ */
+export function getAvailableGWProviders(hasParent: boolean): ApiGatewayProvider[] {
+  return (Object.keys(apiGatewayProviderPresets) as ApiGatewayProvider[]).filter(
+    (provider) => isGWProviderCompatibleWithPlacement(provider, hasParent)
+  );
+}

--- a/src/engine/ServerStateManager.ts
+++ b/src/engine/ServerStateManager.ts
@@ -336,6 +336,7 @@ export class ServerStateManager {
             blockedRequests: stats.blockedRequests,
             authFailures: stats.authFailures,
             rateLimitHits: stats.rateLimitHits,
+            capacityRejections: stats.capacityRejections,
             avgLatency: 0,
             activeConnections: stats.activeRequests,
           };

--- a/src/engine/SimulationEngine.ts
+++ b/src/engine/SimulationEngine.ts
@@ -1159,6 +1159,7 @@ export class SimulationEngine {
             blockedRequests: stats.blockedRequests,
             authFailures: stats.authFailures,
             rateLimitHits: stats.rateLimitHits,
+            capacityRejections: stats.capacityRejections,
             activeConnections: stats.activeRequests,
             avgLatency: 0,
           };

--- a/src/engine/__tests__/LoadBalancerManager.test.ts
+++ b/src/engine/__tests__/LoadBalancerManager.test.ts
@@ -4,6 +4,10 @@ import type { LoadBalancerNodeData } from '@/types';
 
 const defaultConfig: LoadBalancerNodeData = {
   label: 'Test LB',
+  provider: 'generic',
+  maxConnections: 10000,
+  maxRPS: 5000,
+  baseLatencyMs: 5,
   algorithm: 'round-robin',
   healthCheck: {
     enabled: true,

--- a/src/engine/handlers/ApiGatewayHandler.ts
+++ b/src/engine/handlers/ApiGatewayHandler.ts
@@ -12,6 +12,8 @@ interface GatewayState {
   blockedRequests: number;
   authFailures: number;
   rateLimitHits: number;
+  /** Rejets pour dépassement de capacité (maxConnections) */
+  capacityRejections: number;
   /** Nombre de requêtes actuellement en cours de traitement (forwarded, pas encore répondues) */
   activeRequests: number;
   /** True quand le rate limit a été atteint — bloque toutes nouvelles requêtes jusqu'à ce que activeRequests tombe à 0 */
@@ -35,7 +37,17 @@ export class ApiGatewayHandler implements NodeRequestHandler {
 
   getProcessingDelay(node: GraphNode, speed: number): number {
     const data = node.data as ApiGatewayNodeData;
-    return data.baseLatencyMs / speed;
+    const state = this.gatewayStates.get(node.id);
+    const baseLatency = data.baseLatencyMs;
+
+    // Dégradation de latence sous charge (formule quadratique)
+    if (state && data.maxConnections > 0 && state.activeRequests > 0) {
+      const utilization = state.activeRequests / data.maxConnections;
+      const degradationFactor = 1 + Math.pow(Math.min(utilization, 1), 2);
+      return (baseLatency * degradationFactor) / speed;
+    }
+
+    return baseLatency / speed;
   }
 
   initialize(node: GraphNode): void {
@@ -78,6 +90,13 @@ export class ApiGatewayHandler implements NodeRequestHandler {
     state.lastSeenAuthType = data.authType;
 
     state.totalRequests++;
+
+    // Vérifier la capacité (maxConnections) — la gateway a des limites physiques/cloud
+    if (data.maxConnections > 0 && state.activeRequests >= data.maxConnections) {
+      state.capacityRejections++;
+      state.blockedRequests++;
+      return { action: 'reject', reason: 'capacity' };
+    }
 
     // Vérifier l'authentification (Issue #52 — vrai contrôle de token)
     if (data.authType !== 'none') {
@@ -285,6 +304,7 @@ export class ApiGatewayHandler implements NodeRequestHandler {
     blockedRequests: number;
     authFailures: number;
     rateLimitHits: number;
+    capacityRejections: number;
     activeRequests: number;
   } | null {
     const state = this.gatewayStates.get(nodeId);
@@ -295,6 +315,7 @@ export class ApiGatewayHandler implements NodeRequestHandler {
       blockedRequests: state.blockedRequests,
       authFailures: state.authFailures,
       rateLimitHits: state.rateLimitHits,
+      capacityRejections: state.capacityRejections,
       activeRequests: state.activeRequests,
     };
   }
@@ -316,6 +337,7 @@ export class ApiGatewayHandler implements NodeRequestHandler {
       blockedRequests: 0,
       authFailures: 0,
       rateLimitHits: 0,
+      capacityRejections: 0,
       activeRequests: 0,
       isRateLimited: false,
     };

--- a/src/engine/handlers/LoadBalancerHandler.ts
+++ b/src/engine/handlers/LoadBalancerHandler.ts
@@ -11,14 +11,26 @@ export class LoadBalancerHandler implements NodeRequestHandler {
   readonly nodeType = 'load-balancer';
 
   private manager: LoadBalancerManager;
-  private readonly baseDelay = 5; // LB a une latence très faible
+  /** Connexions actives par LB (compteur propre au LB, pas aux backends) */
+  private activeConnections: Map<string, number> = new Map();
 
   constructor(manager: LoadBalancerManager) {
     this.manager = manager;
   }
 
-  getProcessingDelay(_node: GraphNode, speed: number): number {
-    return this.baseDelay / speed;
+  getProcessingDelay(node: GraphNode, speed: number): number {
+    const data = node.data as LoadBalancerNodeData;
+    const baseLatency = data.baseLatencyMs ?? 5;
+    const active = this.activeConnections.get(node.id) ?? 0;
+
+    // Dégradation de latence sous charge (formule quadratique)
+    if (data.maxConnections > 0 && active > 0) {
+      const utilization = active / data.maxConnections;
+      const degradationFactor = 1 + Math.pow(Math.min(utilization, 1), 2);
+      return (baseLatency * degradationFactor) / speed;
+    }
+
+    return baseLatency / speed;
   }
 
   initialize(node: GraphNode): void {
@@ -28,6 +40,7 @@ export class LoadBalancerHandler implements NodeRequestHandler {
 
   cleanup(nodeId: string): void {
     this.manager.cleanup(nodeId);
+    this.activeConnections.delete(nodeId);
   }
 
   handleRequestArrival(
@@ -36,9 +49,17 @@ export class LoadBalancerHandler implements NodeRequestHandler {
     outgoingEdges: GraphEdge[],
     allNodes: GraphNode[]
   ): RequestDecision {
+    const data = node.data as LoadBalancerNodeData;
+
     // Pas d'edges sortants = pas de backends
     if (outgoingEdges.length === 0) {
       return { action: 'respond', isError: true };
+    }
+
+    // Vérifier la capacité du LB lui-même (maxConnections)
+    const active = this.activeConnections.get(node.id) ?? 0;
+    if (data.maxConnections > 0 && active >= data.maxConnections) {
+      return { action: 'reject', reason: 'capacity' };
     }
 
     // Enregistrer les backends si pas déjà fait
@@ -55,7 +76,7 @@ export class LoadBalancerHandler implements NodeRequestHandler {
 
     if (!selectedBackendId) {
       // Aucun backend disponible/healthy
-      return { action: 'reject', reason: 'capacity' };
+      return { action: 'reject', reason: 'no-healthy-backend' };
     }
 
     // Trouver l'edge correspondant au backend sélectionné
@@ -65,7 +86,8 @@ export class LoadBalancerHandler implements NodeRequestHandler {
       return { action: 'respond', isError: true };
     }
 
-    // Enregistrer la requête envoyée
+    // Incrémenter les connexions actives du LB + enregistrer la requête
+    this.activeConnections.set(node.id, active + 1);
     this.manager.recordRequestSent(node.id, selectedBackendId);
 
     return {
@@ -109,6 +131,12 @@ export class LoadBalancerHandler implements NodeRequestHandler {
     context: RequestContext,
     isError: boolean
   ): ResponseDecision {
+    // Décrémenter les connexions actives du LB
+    const active = this.activeConnections.get(node.id) ?? 0;
+    if (active > 0) {
+      this.activeConnections.set(node.id, active - 1);
+    }
+
     // Le noeud suivant dans le path (après le LB) est le backend sélectionné
     const lbIndex = context.currentPath.indexOf(node.id);
     if (lbIndex >= 0 && lbIndex + 1 < context.currentPath.length) {

--- a/src/engine/handlers/types.ts
+++ b/src/engine/handlers/types.ts
@@ -63,7 +63,8 @@ export type RejectionReason =
   | 'queue-full'
   | 'no-token'
   | 'token-expired'
-  | 'token-invalid';
+  | 'token-invalid'
+  | 'no-healthy-backend';
 
 /**
  * Décision retournée par un handler après traitement

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -950,6 +950,16 @@ export interface LoadBalancerUtilization {
 export interface LoadBalancerNodeData {
   label: string;
   status?: NodeStatus;
+
+  /** Provider/implémentation du load balancer (ex: nginx, haproxy, aws-alb) */
+  provider: string;
+  /** Nombre maximum de connexions simultanées */
+  maxConnections: number;
+  /** Requêtes par seconde maximum */
+  maxRPS: number;
+  /** Latence de base en ms (dépend du provider) */
+  baseLatencyMs: number;
+
   algorithm: LoadBalancerAlgorithm;
 
   healthCheck: LoadBalancerHealthCheck;
@@ -965,6 +975,10 @@ export interface LoadBalancerNodeData {
 /** Valeurs par defaut pour un noeud Load Balancer (round-robin, health check actif). */
 export const defaultLoadBalancerNodeData: LoadBalancerNodeData = {
   label: 'Load Balancer',
+  provider: 'generic',
+  maxConnections: 10000,
+  maxRPS: 5000,
+  baseLatencyMs: 5,
   algorithm: 'round-robin',
   healthCheck: {
     enabled: true,
@@ -1172,6 +1186,7 @@ export interface ApiGatewayUtilization {
   avgLatency: number;
   activeConnections: number;
   rateLimitHits: number;
+  capacityRejections: number;
 }
 
 /**
@@ -1181,6 +1196,13 @@ export interface ApiGatewayUtilization {
 export interface ApiGatewayNodeData {
   label: string;
   status?: NodeStatus;
+
+  /** Provider/implémentation de l'API Gateway (ex: kong, aws-api-gateway) */
+  provider: string;
+  /** Nombre maximum de connexions simultanées */
+  maxConnections: number;
+  /** Requêtes par seconde maximum */
+  maxRPS: number;
 
   // Authentication
   authType: ApiGatewayAuthType;
@@ -1603,6 +1625,9 @@ export const defaultCloudFunctionData: CloudFunctionNodeData = {
 
 export const defaultApiGatewayNodeData: ApiGatewayNodeData = {
   label: 'API Gateway',
+  provider: 'generic',
+  maxConnections: 10000,
+  maxRPS: 5000,
   authType: 'none',
   authFailureRate: 0,
   autoTokenMode: 'valid',


### PR DESCRIPTION
…alancer

Introduce provider-based configuration (nginx, HAProxy, AWS ALB/NLB, Kong, etc.) with realistic presets for max connections, RPS, base latency, and supported algorithms/auth types. Add capacity rejection logic and latency degradation under load for both components. Expose Zustand stores for Playwright e2e tests.