### PR TITLE
fix(build): resolve TypeScript errors blocking Docker production build

### DIFF
--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -27,7 +27,7 @@ export default function SimulatorPage() {
   // Expose stores on window for Playwright e2e tests (dev only)
   useEffect(() => {
     if (process.env.NODE_ENV !== 'production') {
-      const w = window as Record<string, unknown>;
+      const w = window as unknown as Record<string, unknown>;
       w.__archStore = useArchitectureStore;
       w.__appStore = useAppStore;
       w.__simStore = useSimulationStore;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,11 +7,7 @@ export default defineConfig({
     globals: true,
     setupFiles: './src/test/setup.ts',
     pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
+    fileParallelism: false,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- simulator/page.tsx: cast window via 'unknown' first (TS2352 strict overlap rejected the direct Record cast)
- vitest.config.ts: replace removed-in-v4 'poolOptions.threads.singleThread' with top-level 'fileParallelism: false'